### PR TITLE
Reference esa name and subscript where appropriate

### DIFF
--- a/gui.lisp
+++ b/gui.lisp
@@ -367,9 +367,9 @@ active."
 (defun make-view-subscript-generator (climacs)
   #'(lambda (name)
       (1+ (reduce #'max (remove name (views climacs)
-                         :test-not #'string= :key #'name)
+                         :test-not #'string= :key #'esa-utils:name)
            :initial-value 0
-           :key #'subscript))))
+           :key #'esa-utils:subscript))))
 
 (defun clone-view-for-climacs (climacs view &rest initargs)
   "Clone `view' and add it to `climacs's list of views."


### PR DESCRIPTION
This seems to fix an issue reading files that I have.

On master branch, when executing the `Find File` command, I get the error:
```
There is no applicable method for the generic function                                                                                                                                               
  #<STANDARD-GENERIC-FUNCTION CLIMACS-CORE:SWITCH-TO-VIEW (1)>                                                                                                                                       
when called with arguments                                                                                                                                                                           
  (#<CLIM-CLX::CLX-CLIMACS-PANE-DUMMY TEXTUAL-DREI-SYNTAX-VIEW {10019CFF23}>                                                                                                                         
   #<DREI:TEXTUAL-DREI-SYNTAX-VIEW name: crimes.lisp 1 {100C2701E3}>).
   [Condition of type SIMPLE-ERROR]
```

It looks to me like my patch does what was intended to happen. 